### PR TITLE
fix(fact): null values comparison

### DIFF
--- a/Diwen.Xbrl.Tests/Xml/FactTests.cs
+++ b/Diwen.Xbrl.Tests/Xml/FactTests.cs
@@ -13,6 +13,9 @@
 //  OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS 
 //  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+using System.Collections.Generic;
+using System.Xml;
+
 namespace Diwen.Xbrl.Tests.Xml
 {
     using Diwen.Xbrl.Xml;
@@ -26,5 +29,40 @@ namespace Diwen.Xbrl.Tests.Xml
             var fact = new Fact();
             Assert.NotEmpty(fact.ToString());
         }
+        
+        [Theory]
+        [InlineData("x", "x", true)]
+        [InlineData("x", null, false)]
+        [InlineData(null, "x", false)]
+        [InlineData(null, null, true)]
+        public static void FactWithNullValue(string value1, string value2, bool expected) =>
+            Assert.Equal(EqualityComparer<Fact>.Default.Equals(
+                new Fact { Value = value1 }, 
+                new Fact { Value = value2 }
+                ), expected);
+        
+        [Theory]
+        [InlineData("x", "x", true)]
+        [InlineData("x", null, false)]
+        [InlineData(null, "x", false)]
+        [InlineData(null, null, true)]
+        public static void FactWithNullMetric(string value1, string value2, bool expected) =>
+            Assert.Equal(EqualityComparer<Fact>.Default.Equals(
+                new Fact { Metric = new XmlQualifiedName(value1) }, 
+                new Fact { Metric = new XmlQualifiedName(value2) }
+            ), expected);
+        
+        [Theory]
+        [InlineData("x", "x", true)]
+        [InlineData("x", null, false)]
+        [InlineData(null, "x", false)]
+        [InlineData(null, null, true)]
+        public static void FactWithNullDecimals(string value1, string value2, bool expected) =>
+            Assert.Equal(EqualityComparer<Fact>.Default.Equals(
+                new Fact { Decimals = value1 }, 
+                new Fact { Decimals = value2 }
+            ), expected);
+
+
     }
 }

--- a/Diwen.Xbrl/Xml/Fact.cs
+++ b/Diwen.Xbrl/Xml/Fact.cs
@@ -204,30 +204,17 @@ namespace Diwen.Xbrl.Xml
 
         /// <summary/>
         public override int GetHashCode()
-        => Value.GetHashCode();
+        => Value?.GetHashCode() ?? 0;
 
         #region IEquatable implementation
 
         /// <summary/>
-        public bool Equals(Fact other)
-        {
-            var result = other != null
-                && Value.Equals(other.Value, StringComparison.Ordinal)
-                && Metric.Equals(other.Metric)
-                && Decimals.Equals(other.Decimals, StringComparison.Ordinal);
-
-            if (result)
-                result = Unit == null
-                    ? other.Unit == null
-                    : Unit.Equals(other.Unit);
-
-            // if (result)
-            //     result = Context == null
-            //         ? other.Context == null
-            //         : Context.Equals(other.Context);
-
-            return result;
-        }
+        public bool Equals(Fact other) =>
+            other != null 
+            && string.Equals(Value, other.Value, StringComparison.Ordinal) 
+            && string.Equals(Decimals, other.Decimals, StringComparison.Ordinal)
+            && (Metric?.Equals(other.Metric) ?? other.Unit == null) 
+            && (Unit?.Equals(other.Unit) ?? other.Unit == null);
 
         #endregion
     }


### PR DESCRIPTION
Expanded the null checks, we're facing this because right now we just add a lot of facts and cleanup the null values afterwards. You could consider use a `record` for `Fact` instead.