### PR TITLE
Add EbaDocumentation to PropertyGroup in CSV Taxonomy

### DIFF
--- a/Diwen.Xbrl/Csv/Taxonomy/PropertyGroup.cs
+++ b/Diwen.Xbrl/Csv/Taxonomy/PropertyGroup.cs
@@ -15,6 +15,10 @@ namespace Diwen.Xbrl.Csv.Taxonomy
         [JsonPropertyName("dimensions")]
         public Dictionary<string, string> Dimensions { get; set; }
 
+        /// <summary/>
+        [JsonPropertyName("eba:documentation")]
+        public EbaDocumentation EbaDocumentation { get; set; }
+
         private readonly HashSet<string> excludeDimensions = new(["concept", "unit"]);
 
         private Dictionary<string, string> dimensionValues;


### PR DESCRIPTION
The goal of this PR is to add the `EbaDocumentation` to the `PropertyGroup`