### PR TITLE
Don't export final when null in xbrl-csv

### DIFF
--- a/Diwen.Xbrl/Package/DocumentInfo.cs
+++ b/Diwen.Xbrl/Package/DocumentInfo.cs
@@ -33,6 +33,7 @@ namespace Diwen.Xbrl.Package
         public List<string> Extends { get; set; }
 
         /// <summary/>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonPropertyName("final")]
         public Dictionary<string, bool> Final { get; set; }
 


### PR DESCRIPTION
The `final` property shouldn't be exported when it's null.